### PR TITLE
Use https where applicable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -qq update \
     && apt-get -qqy upgrade \
     && apt-get -qqy install --no-install-recommends bash sudo procps ca-certificates wget supervisor mysql-server mysql-client apache2 pwgen unzip php5-ldap
-RUN wget --quiet -O - http://packages.icinga.org/icinga.key | apt-key add -
+RUN wget --quiet -O - https://packages.icinga.org/icinga.key | apt-key add -
 RUN echo "deb http://packages.icinga.org/debian icinga-wheezy-snapshots main" >> /etc/apt/sources.list
 RUN apt-get -qq update \
     && apt-get -qqy install --no-install-recommends icinga2 icinga2-ido-mysql icinga-web nagios-plugins icingaweb2 \
@@ -24,7 +24,7 @@ RUN chmod u+x /opt/run
 
 # Temporary hack to get icingaweb2 modules via git
 RUN mkdir -p /etc/icingaweb2/enabledModules
-RUN wget --no-cookies --no-check-certificate "https://github.com/Icinga/icingaweb2/archive/master.zip" -O /tmp/icingaweb2.zip
+RUN wget --no-cookies "https://github.com/Icinga/icingaweb2/archive/master.zip" -O /tmp/icingaweb2.zip
 RUN unzip /tmp/icingaweb2.zip "icingaweb2-master/modules/doc/*" "icingaweb2-master/modules/monitoring/*" -d "/tmp/icingaweb2"
 RUN cp -R /tmp/icingaweb2/icingaweb2-master/modules/monitoring /etc/icingaweb2/modules/
 RUN cp -R  /tmp/icingaweb2/icingaweb2-master/modules/doc /etc/icingaweb2/modules/


### PR DESCRIPTION
Since both `icinga.org` and `github.com` provide valid SSL certs, there is no point in not using them.
This commit will:

* Download apt key using https instead of http
* Remove '--no-check-certificate' when downloading source from GitHub