### PR TITLE
Changed initfile location and test file location for pki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq update \
     && apt-get -qqy upgrade \
-    && apt-get -qqy install --no-install-recommends bash sudo procps ca-certificates wget supervisor mysql-server mysql-client apache2 pwgen unzip php5-ldap
+    && apt-get -qqy install --no-install-recommends bash sudo procps ca-certificates wget supervisor mysql-server mysql-client apache2 pwgen unzip php5-ldap ssmtp
 RUN wget --quiet -O - https://packages.icinga.org/icinga.key | apt-key add -
 RUN echo "deb http://packages.icinga.org/debian icinga-jessie-snapshots main" >> /etc/apt/sources.list
 RUN apt-get -qq update \
-    && apt-get -qqy install --no-install-recommends icinga2 icinga2-ido-mysql icinga-web nagios-plugins icingaweb2 \
+    && apt-get -qqy install --no-install-recommends icinga2 icinga2-ido-mysql icinga-web nagios-plugins icingaweb2 nagios-nrpe-plugin \
     && apt-get clean
 
 ADD content/ /
@@ -32,7 +32,7 @@ RUN rm -rf /tmp/icingaweb2.zip /tmp/icingaweb2
 
 EXPOSE 80 443 5665
 
-VOLUME  ["/etc/icinga2", "/etc/icinga-web", "/etc/icingaweb2", "/var/lib/mysql", "/var/lib/icinga2"]
+VOLUME  ["/etc/icinga2", "/etc/icinga-web", "/etc/icingaweb2", "/var/lib/mysql", "/var/lib/icinga2", "/etc/ssmtp"]
 
 # Initialize and run Supervisor
 ENTRYPOINT ["/opt/run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq update \
     && apt-get -qqy upgrade \
-    && apt-get -qqy install --no-install-recommends bash sudo procps ca-certificates wget supervisor mysql-server mysql-client apache2 pwgen unzip php5-ldap ssmtp
+    && apt-get -qqy install --no-install-recommends bash sudo procps ca-certificates wget supervisor mysql-server mysql-client apache2 pwgen unzip php5-ldap ssmtp mailutils
 RUN wget --quiet -O - https://packages.icinga.org/icinga.key | apt-key add -
 RUN echo "deb http://packages.icinga.org/debian icinga-jessie-snapshots main" >> /etc/apt/sources.list
 RUN apt-get -qq update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq update \
     && apt-get -qqy upgrade \
-    && apt-get -qqy install --no-install-recommends bash sudo procps ca-certificates wget supervisor mysql-server mysql-client apache2 pwgen unzip php5-ldap ssmtp mailutils
+    && apt-get -qqy install --no-install-recommends bash sudo procps ca-certificates wget supervisor mysql-server mysql-client apache2 pwgen unzip php5-ldap ssmtp mailutils vim
 RUN wget --quiet -O - https://packages.icinga.org/icinga.key | apt-key add -
 RUN echo "deb http://packages.icinga.org/debian icinga-jessie-snapshots main" >> /etc/apt/sources.list
 RUN apt-get -qq update \

--- a/content/opt/run
+++ b/content/opt/run
@@ -2,7 +2,7 @@
 
 set -e
 
-initfile=/etc/icinga2.init
+initfile=/etc/icinga2/run.init
 
 chmod 1777 /tmp
 
@@ -40,7 +40,7 @@ if [[ -L /etc/icinga2/features-enabled/compatlog.conf ]]; then echo "Symlink for
 if [[ -L /etc/icinga2/features-enabled/command.conf ]]; then echo "Symlink for /etc/icinga2/features-enabled/command.conf exists already...skipping"; else ln -s /etc/icinga2/features-available/command.conf /etc/icinga2/features-enabled/command.conf; fi
 
 #icinga2 API cert - regenerate new private key and certificate when running in a new container
-if [ ! -f /etc/icingaweb2/pki/$(hostname).key ]; then echo -n "Generating new private key and certificate for this container..."; icinga2 feature disable api >> /dev/null; icinga2 api setup >> /dev/null; echo "done"; fi
+if [ ! -f /etc/icinga2/pki/$(hostname).key ]; then echo -n "Generating new private key and certificate for this container..."; icinga2 feature disable api >> /dev/null; icinga2 api setup >> /dev/null; echo "done"; fi
 
 usermod -a -G nagios www-data >> /dev/null
 

--- a/content/opt/run
+++ b/content/opt/run
@@ -43,6 +43,7 @@ if [[ -L /etc/icinga2/features-enabled/command.conf ]]; then echo "Symlink for /
 if [ ! -f /etc/icinga2/pki/$(hostname).key ]; then echo -n "Generating new private key and certificate for this container..."; icinga2 feature disable api >> /dev/null; icinga2 api setup >> /dev/null; echo "done"; fi
 
 usermod -a -G nagios www-data >> /dev/null
+chfn -f "nagios at $(hostname)" nagios
 
 update_user_password () {
    (


### PR DESCRIPTION
This will allow for someone to start up the image without specifying any volumes then with the -v and --volume-from option copy the data down to the host and then start the image again specifying each volume path. 