### PR TITLE
removed unnecessary volume-definitions, so that it can be used as baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,5 @@ RUN rm -rf /tmp/director
 
 EXPOSE 80 443 5665
 
-VOLUME  ["/etc/icinga2", "/etc/icinga-web", "/etc/icingaweb2", "/var/lib/mysql", "/var/lib/icinga2", "/etc/ssmtp"]
-
 # Initialize and run Supervisor
 ENTRYPOINT ["/opt/run"]


### PR DESCRIPTION
there is no need to make volume-definitions in dockerfile. the **-v** option works anyway on **docker run**.
but there is a drawback if you define them in dockerfile. please see this issue https://github.com/docker/docker/issues/3639. especially this comment https://github.com/docker/docker/issues/3639#issuecomment-48154253

the problem is, that i want to use your image as baseimage to ADD my icinga-config to /etc/icinga2 while **docker build**, so that the config is part of the image. the ADD command works, but if i want to RUN a chmod in dockerfile nothing changes because the RUN command causes docker to make defined volumes immutable (see github-issue above). but i need chmod, because i get permission-denieds while starting up icinga.

so concluding: please approve, because there is no need to define volumes in dockerfile. **-v** works anyway on **docker run**.

thanks