### PR TITLE
Issue #15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN rm -rf /tmp/icingaweb2.zip /tmp/icingaweb2
 RUN wget --no-cookies "https://github.com/Icinga/icingaweb2-module-director/archive/master.zip" -O /tmp/director.zip
 RUN unzip /tmp/director.zip -d "/tmp/director"
 RUN cp -R /tmp/director/icingaweb2-module-director-master/* /etc/icingaweb2/modules/director/
-RUN rm -rf /tmp/director
+RUN rm -rf /tmp/director.zip /tmp/director
 
 EXPOSE 80 443 5665
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ image.
 1. Based on debian:jessie
 1. Supervisor, Apache2, MySQL, icinga2, icinga-web, icingacli, icingaweb2, and icingaweb2 director module
 1. No SSH.  Use docker [exec](https://docs.docker.com/engine/reference/commandline/exec/) or [nsenter](https://github.com/jpetazzo/nsenter)
-1. If no passwords are not supplied, they will be randomly generated and shown via stdout.
+1. If passwords are not supplied, they will be randomly generated and shown via stdout.
 
 ## Automated build
 

--- a/content/opt/run
+++ b/content/opt/run
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [ -f /opt/custom_run ]; then
-    echo "=>executing /opt/custom_run"
     chmod u+x /opt/custom_run
+    echo "=>executing /opt/custom_run"
     /opt/custom_run
 fi
 

--- a/content/opt/run
+++ b/content/opt/run
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ -f /opt/custom_run ]; then
+    echo "=>executing /opt/custom_run"
+    chmod u+x /opt/custom_run
+    /opt/custom_run
+fi
+
 set -e
 
 initfile=/etc/icinga2/run.init

--- a/content/opt/run
+++ b/content/opt/run
@@ -140,6 +140,7 @@ sed -i 's,mysql://icinga_web:.*@localhost,mysql://icinga_web:'${ICINGA_WEB_PASSW
 sed -i 's,mysql://icinga:.*@localhost,mysql://icinga:'${ICINGA_PASSWORD}'@localhost,g' /etc/icinga-web/conf.d/databases.xml
 
 #icingaweb2
+usermod -a -G icingaweb2 www-data >> /dev/null
 (
     echo "CREATE DATABASE IF NOT EXISTS icingaweb2;"
     echo "GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE VIEW, INDEX, EXECUTE ON icingaweb2.* TO 'icingaweb2'@'localhost' IDENTIFIED BY '${ICINGAWEB2_PASSWORD}';"


### PR DESCRIPTION
e697d81 fixes #15 
- Web 2.0 login page fails file_exists test on /etc/icingaweb2/authentication.ini due to permissions
- In /usr/share/php/Icinga/Application/ApplicationBootstrap.php loadSetupModuleIfNecessary
- This also allows generating the setup token, suggested on the login page, to work.

Everything else is very minor.  Take or leave.

My first pull request, feel free to abuse me, need to learn.