### PR TITLE
add SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ sudo docker run --link graphite:graphite -e ICINGA2_FEATURE_GRAPHITE=true -e ICI
 
 The [Icinga Director](https://github.com/Icinga/icingaweb2-module-director) Icinga Web 2 module is installed and enabled by default.  You can disable the automatic kickstart when the container starts by setting the DIRECTOR_KICKSTART variable to false.  To customize the kickstart settings, modify the /etc/icingaweb2/modules/director/kickstart.ini 
 
+## SSL Support
+
+For enabling of SSL support, just add a volume to `/etc/apache2/ssl`, which contains these files:
+
+- `icinga2.crt`: The certificate file for apache
+- `icinga2.key`: The corresponding private key
+- `icinga2.chain` (optional): If a certificate chain is needed, add this file. Consult your CA-vendor for additional info.
+
 ## Environment variables & Volumes
 
 ```
@@ -63,6 +71,7 @@ DIRECTOR_KICKSTART - true (default).  Set to false to disable director auto kick
 ```
 
 ```
+/etc/apache2/ssl
 /etc/icinga2
 /etc/icingaweb2
 /var/lib/mysql

--- a/content/etc/apache2/sites-available/docker-ssl.conf
+++ b/content/etc/apache2/sites-available/docker-ssl.conf
@@ -1,0 +1,25 @@
+<IfModule mod_ssl.c>
+	<VirtualHost _default_:443>
+		ServerAdmin webmaster@localhost
+
+		DocumentRoot /var/www/html
+
+		ErrorLog ${APACHE_LOG_DIR}/error.log
+		CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+		SSLEngine on
+		SSLCertificateFile /etc/apache2/ssl/icinga2.crt
+		SSLCertificateKeyFile /etc/apache2/ssl/icinga2.key
+		SSLCertificateChainFile /etc/apache2/ssl/icinga2.chain
+
+		<FilesMatch "\.(cgi|shtml|phtml|php)$">
+				SSLOptions +StdEnvVars
+		</FilesMatch>
+		<Directory /usr/lib/cgi-bin>
+				SSLOptions +StdEnvVars
+		</Directory>
+
+	</VirtualHost>
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/content/opt/supervisor/apache2_supervisor
+++ b/content/opt/supervisor/apache2_supervisor
@@ -6,6 +6,20 @@ function shutdown()
     /etc/init.d/apache2 stop
 }
 
+# Enable SSL support if certificates are mounted
+if [ -f /etc/apache2/ssl/icinga2.crt -a -f /etc/apache2/ssl/icinga2.key ]; then
+
+    # If there is no chain needed, we have to generate an empty
+    # file with a single line to interpret it correctly as "no chain"
+    if [ ! -f /etc/apache2/ssl/icinga2.chain ]; then
+        echo > /etc/apache2/ssl/icinga2.chain
+    fi
+    a2enmod ssl
+    a2ensite docker-ssl
+else
+    a2dissite docker-ssl
+fi
+
 echo "`date +"%d.%m.%Y %T.%3N"` - Starting apache2"
 
 /etc/init.d/apache2 start


### PR DESCRIPTION
Closes #53 

I added optional SSL support for apache2.

By adding the volume `/etc/apache2/ssl` with the correct certificate, key and optionally a chain, you can use SSL in icingaweb2.

If there is nothing in `/etc/apache2/ssl/`, SSL settings will get ignored.