### PR TITLE
use ARGs for gitrefs and minifiy install process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ ENV ICINGA2_FEATURE_GRAPHITE false
 ENV ICINGA2_FEATURE_GRAPHITE_HOST graphite
 ENV ICINGA2_FEATURE_GRAPHITE_PORT 2003
 
+ARG GITREF_ICINGAWEB2=master
+ARG GITREF_DIRECTOR=master
+
 RUN apt-get -qq update \
      && apt-get -qqy upgrade \
      && apt-get -qqy install --no-install-recommends \
@@ -47,24 +50,17 @@ RUN wget --quiet -O - https://packages.icinga.org/icinga.key \
 
 ADD content/ /
 
-RUN chmod u+x /opt/supervisor/mysql_supervisor /opt/supervisor/icinga2_supervisor /opt/supervisor/apache2_supervisor /opt/run 
+RUN chmod u+x /opt/supervisor/mysql_supervisor /opt/supervisor/icinga2_supervisor /opt/supervisor/apache2_supervisor /opt/run \
+    && cp -R /etc/icingaweb2/* /etc/icingaweb2.dist \
+    && rm -rf /etc/icingaweb2
 
 # Temporary hack to get icingaweb2 modules via git
-RUN mkdir -p /etc/icingaweb2.dist/enabledModules && \
-  wget --no-cookies "https://github.com/Icinga/icingaweb2/archive/v2.3.4.zip" -O /tmp/icingaweb2.zip && \
-  unzip /tmp/icingaweb2.zip "icingaweb2-2.3.4/modules/doc/*" "icingaweb2-2.3.4/modules/monitoring/*" -d "/tmp/icingaweb2" && \
-  cp -R /tmp/icingaweb2/icingaweb2-2.3.4/modules/monitoring /etc/icingaweb2.dist/modules/ && \
-  cp -R  /tmp/icingaweb2/icingaweb2-2.3.4/modules/doc /etc/icingaweb2.dist/modules/ && \
-  rm -rf /tmp/icingaweb2.zip /tmp/icingaweb2
+RUN wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2/archive/${GITREF_ICINGAWEB2}.tar.gz" \
+  | tar xz --strip-components=2 --directory=/etc/icingaweb2.dist/modules -f - icingaweb2-${GITREF_ICINGAWEB2}/modules/monitoring icingaweb2-${GITREF_ICINGAWEB2}/modules/doc
 
 # Icinga Director
-RUN wget --no-cookies "https://github.com/Icinga/icingaweb2-module-director/archive/master.zip" -O /tmp/director.zip && \
-  unzip /tmp/director.zip -d "/tmp/director" && \
-  cp -R /tmp/director/icingaweb2-module-director-master/* /etc/icingaweb2.dist/modules/director/ && \
-  rm -rf /tmp/director.zip /tmp/director && \
-  cp -R /etc/icingaweb2/* /etc/icingaweb2.dist/ && \
-  cp -R /etc/icinga2 /etc/icinga2.dist && \
-  rm -rf /etc/icingaweb2/modules
+RUN wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/${GITREF_DIRECTOR}.tar.gz" \
+  | tar xz --strip-components=1 --directory=/etc/icingaweb2.dist/modules/director --exclude=.gitignore -f -
 
 EXPOSE 80 443 5665
 

--- a/content/opt/run
+++ b/content/opt/run
@@ -40,6 +40,7 @@ if [ ! -f "${initfile}" ]; then
 if [ "$(ls -A /etc/icingaweb2)" ]; then
   echo "=>/etc/icingaweb2 check OK"
 else
+  mkdir /etc/icingaweb2.dist/enabledModules
   cp -R /etc/icingaweb2.dist/* /etc/icingaweb2/
   chown www-data:icingaweb2 /etc/icingaweb2
   chmod 2770 /etc/icingaweb2

--- a/content/opt/run
+++ b/content/opt/run
@@ -170,8 +170,13 @@ ICINGAADMIN_PASSWORD=`openssl passwd -1 "icinga"`
     echo "quit"
 ) |
 mysql
-if [[ -L /etc/icingaweb2/enabledModules/monitoring ]]; then echo "Symlink for /etc/icingaweb2/enabledModules/monitoring exists already...skipping"; else ln -s /etc/icingaweb2/modules/monitoring /etc/icingaweb2/enabledModules/monitoring; fi
-if [[ -L /etc/icingaweb2/enabledModules/doc ]]; then echo "Symlink for /etc/icingaweb2/enabledModules/doc exists already...skipping"; else ln -s /etc/icingaweb2/modules/doc /etc/icingaweb2/enabledModules/doc; fi
+
+[[ ! -L /etc/icingaweb2/enabledModules/monitoring ]] \
+	&& ln -sT /etc/icingaweb2/modules/monitoring /etc/icingaweb2/enabledModules/monitoring
+
+[[ ! -L /etc/icingaweb2/enabledModules/doc ]] \
+	&& ln -sT /etc/icingaweb2/modules/doc /etc/icingaweb2/enabledModules/doc
+
 sed -i 's,icingaweb2_changeme,'${ICINGAWEB2_PASSWORD}',g' /etc/icingaweb2/resources.ini
 sed -i 's,icinga2-ido-mysq_changeme,'${IDO_PASSWORD}',g' /etc/icingaweb2/resources.ini
 mkdir -p /var/log/icingaweb2
@@ -190,7 +195,9 @@ if [[ $(grep director /etc/icinga2/conf.d/api-users.conf) ]]; then echo "=> Dire
 sed -i 's,directorapi,'${DIRECTOR_API_PASSWORD}',g' /etc/icinga2/conf.d/api-users.conf
 sed -i 's,changeme,'$(hostname)',g' /etc/icingaweb2/modules/director/kickstart.ini
 sed -i 's,directorapi,'${DIRECTOR_API_PASSWORD}',g' /etc/icingaweb2/modules/director/kickstart.ini
-if [[ -L /etc/icingaweb2/enabledModules/director ]]; then echo "Symlink for /etc/icingaweb2/enabledModules/director exists already...skipping"; else ln -s /etc/icingaweb2/modules/director /etc/icingaweb2/enabledModules/director; fi
+
+[[ ! -L /etc/icingaweb2/enabledModules/director ]] \
+	&& ln -sT /etc/icingaweb2/modules/director /etc/icingaweb2/enabledModules/director
 
 /etc/init.d/mysql stop
 


### PR DESCRIPTION
So if somebody wants another icingaweb2 module or director version, you can adjust it. Additionally it's much easier to read.