### PR TITLE
initial ARM support (do not merge, hazardous)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for icinga2 with icingaweb2
 # https://github.com/jjethwa/icinga2
 
-FROM debian:jessie
+FROM multiarch/debian-debootstrap:armhf-jessie
 
 MAINTAINER Jordan Jethwa
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ For https-redirection or http/https dualstack consult `APACHE2_HTTP` env-variabl
 
 To use your own modules, you're able to install these into `enabledModules`-folder of your `/etc/icingaweb2` volume.
 
+# RaspberryPi-Support
+
+The docker-image is also working on RaspberryPi, Odroid C2 and other ARM devices. Checkout the [arm-tags on docker hub](https://hub.docker.com/r/jordan/icinga2/tags/).
+
 ## Environment variables Reference
 
 | Environmental Variable | Default Value | Description |


### PR DESCRIPTION
I had been able to build the icinga2-image on an Odroid C2. And actually changing just one line and about 6 mins buildtime were everything to do.

I'm stunned of the Netways and the debian guys. They're providing armhf-images for RaspberryPi (and other ARM devices) for all apt-packages needed in this Dockerfile. I had the fear of having to compile and install icinga2 manually on my box. But when there is a docker-container, I'll take it! This is awesome.

As this is so easy, I would consider having raspberryPi support. But there are a few topics to solve:
- [ ] docker-hub building
- [ ] branch-model

Do not merge this, as the PR is currently directed to master, merging this would be hazardous.