### PR TITLE
get rid of supervisord's UserWarning

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -48,6 +48,6 @@ Icinga Web 2 (/icingaweb2) default credentials: ${ICINGAWEB2_ADMIN_USER}:${ICING
 Starting Supervisor.
 END
 
-/usr/bin/supervisord -n &
+/usr/bin/supervisord -c /etc/supervisor/supervisord.conf -n &
 trap "supervisorctl shutdown && wait" SIGTERM
 wait


### PR DESCRIPTION
supervisord complains about security if no -c option specified