### PR TITLE
validate config to log to stdout before starting supvervisor

### DIFF
--- a/content/opt/run
+++ b/content/opt/run
@@ -48,6 +48,8 @@ Icinga Web 2 (/icingaweb2) default credentials: ${ICINGAWEB2_ADMIN_USER}:${ICING
 Starting Supervisor.
 END
 
+icinga2 daemon --validate
+
 /usr/bin/supervisord -c /etc/supervisor/supervisord.conf -n &
 trap "supervisorctl shutdown && wait" SIGTERM
 wait


### PR DESCRIPTION
validates config before starting supervisor. The validation process gets logged to docker, which is useful.

Improves behavior for #95 