### PR TITLE
change pulling icinga key from wget to curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
      && rm -rf /var/lib/apt/lists/*
 
 RUN export DEBIAN_FRONTEND=noninteractive \
-     && curl -ks https://packages.icinga.org/icinga.key \
+     && curl -s https://packages.icinga.com/icinga.key \
      | apt-key add - \
      && echo "deb http://packages.icinga.org/debian icinga-$(lsb_release -cs) main" > /etc/apt/sources.list.d/icinga2.list \
      && export DEBIAN_FRONTEND=noninteractive \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
      && rm -rf /var/lib/apt/lists/*
 
 RUN export DEBIAN_FRONTEND=noninteractive \
-     && wget --quiet -O - https://packages.icinga.org/icinga.key \
+     && curl -ks https://packages.icinga.org/icinga.key \
      | apt-key add - \
      && echo "deb http://packages.icinga.org/debian icinga-$(lsb_release -cs) main" > /etc/apt/sources.list.d/icinga2.list \
      && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Hi Jordan!

I had problems with wget on the container not being able to verify the https certificate of the packages.icinga.org . Since you already install curl, I changed the way to pull the certificate to this because I can use `-k` to omit certificate checking.

I know omitting this is not a good thing but since I couldn't check it anyway I decided to go for the uncecked version.

Maybe pulling the key from packages.icinga.com could help, too.

Cheers,
Thomas