### PR TITLE
Add support for custom locales

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
           curl \
           dnsutils \
           gnupg \
+          locales \
           lsb-release \
           mailutils \
           mariadb-client \

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ All these folders are configured and able to get mounted as volume. The bottom o
 | Volume | ro/rw | Description & Usage |
 | ------ | ----- | ------------------- |
 | /etc/apache2/ssl | **ro** | Mount optional SSL-Certificates (see SSL Support) |
+| /etc/locale.gen | **ro** | In format of the well known locale.gen file. All locales listed in this file will get generated. |
 | /etc/ssmtp/revaliases | **ro** | revaliases map (see Sending Notification Mails) |
 | /etc/ssmtp/ssmtp.conf | **ro** | ssmtp configuration (see Sending Notification Mails) |
 | /etc/icinga2 | rw | Icinga2 configuration folder |

--- a/content/opt/run
+++ b/content/opt/run
@@ -33,6 +33,13 @@ export ICINGAWEB2_DIRECTOR_MYSQL_USER=${ICINGAWEB2_DIRECTOR_MYSQL_USER:-${DEFAUL
 export ICINGAWEB2_DIRECTOR_MYSQL_PASS=${ICINGAWEB2_DIRECTOR_MYSQL_PASS:-${DIRECTOR_PASSWORD:-${DEFAULT_MYSQL_PASS}}}
 export ICINGAWEB2_DIRECTOR_MYSQL_DATA=${ICINGAWEB2_DIRECTOR_MYSQL_DATA:-icingaweb2_director}
 
+# Generate the system wide locales in the background.
+# It may take a long time, depending on the mounted /etc/locale.gen.
+# The only part, where locale processing is known to be necessary, is
+# the Icingaweb2 translation plugin and locale-gen should be finished
+# until the first webpage is started.
+locale-gen &
+
 run-parts --lsbsysinit --exit-on-error -- /opt/setup
 
 cat <<-END


### PR DESCRIPTION
Generate the locales in background during bootup. The only known part, which requires working locales, is the translator plugin. So it should be done until the container is booted up fully.

Also as, the process is done in background, it won't increase the bootup/restart time on multicore systems and the process is completely parametrized.

Fixes #101 