### PR TITLE
fix certificate check in setup

### DIFF
--- a/content/opt/setup/50-icinga2
+++ b/content/opt/setup/50-icinga2
@@ -36,7 +36,7 @@ chown -R nagios:root /etc/icinga2
 icinga2 feature enable ido-mysql livestatus compatlog command
 
 #icinga2 API cert - regenerate new private key and certificate when running in a new container
-if [ ! -f "/etc/icinga2/pki/$(hostname).key" ]; then
+if [ ! -f "/var/lib/icinga2/certs/$(hostname).key" ]; then
 	icinga2 node setup --master
 fi
 


### PR DESCRIPTION
I checked in my containers and there was nothing in /etc/icinga2/pki after bootstrapping. Certificates are created in /var/lib/icinga2/certs.