### PR TITLE
Add openssh-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       unzip \
       wget \
       libdbd-mysql-perl \
+      openssh-client\
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
there is a problem with the check_by_ssh function.
I tried to run my conf which uses check_by_ssh to check disk space and other stuff and if i run it in the container without further configuration it wont perform the check and throw the error:

UNKNOWN - check_by_ssh: Remote command '/usr/local/nagios/libexec/check_procs -t 30 -w 20 -c 27 -a '/usr/sbin/nginx'' returned status 3

But after installing the OpenSSH-Client Module it runs fine.