### PR TITLE
Set timezone based on TZ environment variable

### DIFF
--- a/content/opt/setup/11-timezone
+++ b/content/opt/setup/11-timezone
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+. /opt/helpers
+
+[ -n "${TZ-}" ] || exit 0
+
+echo "=> Setting timezone to ${TZ}"
+
+TZFILE="/usr/share/zoneinfo/${TZ}"
+if [ ! -f "${TZFILE}" ]; then
+	echo "Timezone ${TZ} not available, using default timezone"
+	exit 0
+fi
+
+ln -sf "${TZFILE}" /etc/localtime
+dpkg-reconfigure -f noninteractive tzdata


### PR DESCRIPTION
Setting the TZ environment variable won't affect the timezone of the processes started by the supervisor since it trims the environmentpassed to the started child processes.

The proper way to set the timezone in Debian is to write the timezone name to /etc/timezone, adjust the /etc/localtime symlink, and finally reconfigure the tzdata package. We do this in an early setup script.

Fixes #123