### PR TITLE
Switch install recommends on for icinga packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  | apt-key add - \
  && echo "deb http://packages.icinga.org/debian icinga-$(lsb_release -cs) main" > /etc/apt/sources.list.d/icinga2.list \
  && apt-get update \
- && apt-get install -y --no-install-recommends \
+ && apt-get install -y --install-recommends \
       icinga2 \
       icinga2-ido-mysql \
       icingacli \


### PR DESCRIPTION
This will install the recommended packages for the icinga packges.

Doing this to ensure plugins have the perl libs and supporting tools
they need to run.