### PR TITLE
#193 change icinga2.log messaging to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,10 @@ RUN true \
  && mkdir /etc/icinga2 \
  && usermod -aG icingaweb2 www-data \
  && usermod -aG nagios www-data \
+ && mkdir /var/log/icinga2 \
+ && chmod 755 /var/log/icinga2 \
+ && chown nagios:adm /var/log/icinga2 \
+ && ln -sf /dev/stdout /var/log/icinga2/icinga2.log \
  && rm -rf \
      /var/lib/mysql/* \
  && chmod u+s,g+s \


### PR DESCRIPTION
the default icinga2.log is used by Icinga to write any log message. It makes the container volume bigger and this could be avoided by send all log messages to stdout in a docker environment.