### PR TITLE
Debian upgrade and msmtp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,10 +114,6 @@ ADD content/ /
 RUN true \
  && sed -i 's/vars\.os.*/vars.os = "Docker"/' /etc/icinga2/conf.d/hosts.conf \
  && mv /etc/icingaweb2/ /etc/icingaweb2.dist \
- && mkdir -p /etc/icingaweb2/enabledModules \
- && ln -fs /usr/local/share/icingaweb2/modules/ipl /etc/icingaweb2/enabledModules/ \
- && ln -fs /usr/local/share/icingaweb2/modules/incubator /etc/icingaweb2/enabledModules/ \
- && ln -fs /usr/local/share/icingaweb2/modules/reactbundle /etc/icingaweb2/enabledModules/ \
  && mv /etc/icinga2/ /etc/icinga2.dist \
  && mkdir -p /etc/icinga2 \
  && usermod -aG icingaweb2 www-data \
@@ -130,8 +126,7 @@ RUN true \
  && chmod u+s,g+s \
      /bin/ping \
      /bin/ping6 \
-     /usr/lib/nagios/plugins/check_icmp \
- && ln -fs /usr/bin/msmtp /usr/sbin/sendmail
+     /usr/lib/nagios/plugins/check_icmp
 
 EXPOSE 80 443 5665
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # Dockerfile for icinga2 with icingaweb2
 # https://github.com/jjethwa/icinga2
 
-FROM debian:stretch
-
-MAINTAINER Jordan Jethwa
+FROM debian:buster
 
 ENV APACHE2_HTTP=REDIRECT \
     ICINGA2_FEATURE_GRAPHITE=false \
@@ -22,7 +20,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
       apache2 \
-      ca-cacert \
       ca-certificates \
       curl \
       dnsutils \
@@ -45,11 +42,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       procps \
       pwgen \
       snmp \
-      ssmtp \
+      msmtp \
       sudo \
       supervisor \
       unzip \
       wget \
+ && apt-get --purge remove exim4 exim4-base exim4-config exim4-daemon-light \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -110,13 +108,13 @@ RUN true \
  && mkdir -p /var/log/icinga2 \
  && chmod 755 /var/log/icinga2 \
  && chown nagios:adm /var/log/icinga2 \
- # && ln -sf /dev/stdout /var/log/icinga2/icinga2.log \
  && rm -rf \
      /var/lib/mysql/* \
  && chmod u+s,g+s \
      /bin/ping \
      /bin/ping6 \
-     /usr/lib/nagios/plugins/check_icmp
+     /usr/lib/nagios/plugins/check_icmp \
+ && ln -fs /usr/bin/msmtp /usr/sbin/sendmail
 
 EXPOSE 80 443 5665
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,26 +72,40 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-ARG GITREF_DIRECTOR=master
 ARG GITREF_MODGRAPHITE=master
 ARG GITREF_MODAWS=master
+ARG GITREF_REACTBUNDLE=v0.7.0
+ARG GITREF_INCUBATOR=v0.5.0
+ARG GITREF_IPL=v0.3.0
 
 RUN mkdir -p /usr/local/share/icingaweb2/modules/ \
 # Icinga Director
  && mkdir -p /usr/local/share/icingaweb2/modules/director/ \
- && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/${GITREF_DIRECTOR}.tar.gz" \
+ && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/v1.7.0.tar.gz" \
  | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/director --exclude=.gitignore -f - \
 # Icingaweb2 Graphite
  && mkdir -p /usr/local/share/icingaweb2/modules/graphite \
- && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-graphite/archive/${GITREF_MODGRAPHITE}.tar.gz" \
- | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/graphite -f - icingaweb2-module-graphite-${GITREF_MODGRAPHITE}/ \
+ && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-graphite/archive/v1.1.0.tar.gz" \
+ | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/graphite -f - \
 # Icingaweb2 AWS
  && mkdir -p /usr/local/share/icingaweb2/modules/aws \
- && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-aws/archive/${GITREF_MODAWS}.tar.gz" \
- | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/aws -f - icingaweb2-module-aws-${GITREF_MODAWS}/ \
+ && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-aws/archive/v1.0.0.tar.gz" \
+ | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/aws -f - \
  && wget -q --no-cookies "https://github.com/aws/aws-sdk-php/releases/download/2.8.30/aws.zip" \
  && unzip -d /usr/local/share/icingaweb2/modules/aws/library/vendor/aws aws.zip \
  && rm aws.zip \
+# Module Reactbundle
+ && mkdir -p /usr/local/share/icingaweb2/modules/reactbundle/ \
+ && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-reactbundle/archive/v0.7.0.tar.gz" \
+ | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/reactbundle -f - \
+# Module Incubator
+ && mkdir -p /usr/local/share/icingaweb2/modules/incubator/ \
+ && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-incubator/archive/v0.5.0.tar.gz" \
+ | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/incubator -f - \
+# Module Ipl
+ && mkdir -p /usr/local/share/icingaweb2/modules/ipl/ \
+ && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-ipl/archive/v0.3.0.tar.gz" \
+ | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/ipl -f - \
  && true
 
 ADD content/ /
@@ -100,7 +114,10 @@ ADD content/ /
 RUN true \
  && sed -i 's/vars\.os.*/vars.os = "Docker"/' /etc/icinga2/conf.d/hosts.conf \
  && mv /etc/icingaweb2/ /etc/icingaweb2.dist \
- && mkdir -p /etc/icingaweb2 \
+ && mkdir -p /etc/icingaweb2/enabledModules \
+ && ln -fs /usr/local/share/icingaweb2/modules/ipl /etc/icingaweb2/enabledModules/ \
+ && ln -fs /usr/local/share/icingaweb2/modules/incubator /etc/icingaweb2/enabledModules/ \
+ && ln -fs /usr/local/share/icingaweb2/modules/reactbundle /etc/icingaweb2/enabledModules/ \
  && mv /etc/icinga2/ /etc/icinga2.dist \
  && mkdir -p /etc/icinga2 \
  && usermod -aG icingaweb2 www-data \

--- a/README.md
+++ b/README.md
@@ -122,14 +122,16 @@ root:<YOUR_MAILBOX>
 default:<YOUR_MAILBOX>
 ```
 
-These files have to get mounted into the container. Add these flags to your `docker run`-command:
+As a last config change, edit the `data/icinga/etc/icinga2/conf.d/users.conf` and change the e-mail address `root@localhost` to either `root` or a valid external address. This must be done as msmtp interprets all addresses with an at-sign as external and the transport will fail. If the address is changed to `root` the aliasing feature will use your root alias instead.
+
+These files have to be mounted into the container. Add these flags to your `docker run`-command:
 
 ```
 -v $(pwd)/msmtp/aliases:/etc/msmtp/aliases:ro
 -v $(pwd)/msmtp/msmtprc:/etc/msmtp/msmtprc:ro
 ```
 
-If you are using the `docker-compose` file, uncomment the settings for these files under the icinga2 node.
+If you are using the `docker-compose` file, uncomment the settings for these files under the icinga2 node and rebuild.
 
 
 ## SSL Support

--- a/README.md
+++ b/README.md
@@ -86,43 +86,51 @@ The container gets automatically configured as an API master. But it has some ca
 
 ## Sending Notification Mails
 
-The container has `ssmtp` installed, which forwards mails to a preconfigured static server.
+The container has `msmtp` installed, which forwards mails to a preconfigured SMTP server (MTA).
 
-You have to create the files `ssmtp.conf` for general configuration and `revaliases` (mapping from local Unix-user to mail-address).
+The full documentation for [msmtp is found here](https://marlam.de/msmtp).
 
-```
-# ssmtp.conf
-root=<E-Mail address to use on>
-mailhub=smtp.<YOUR_MAILBOX>:587
-UseSTARTTLS=YES
-AuthUser=<Username for authentication (mostly the complete e-Mail-address)>
-AuthPass=<YOUR_PASSWORD>
-FromLineOverride=NO
-```
-**But be careful, ssmtp is not able to process special chars within the password correctly!**
-
-`revaliases` follows the format: `Unix-user:e-Mail-address:server`.
-Therefore the e-Mail-address has to match the `root`'s value in `ssmtp.conf`
-Also server has to match mailhub from `ssmtp.conf` **but without the port**.
+You have to edit the file `msmtp/msmtprc` for general configuration and `msmtp/aliases` (mapping from local Unix-user to mail-address). Please note that the example file can be heavily changed and secured, so read the msmtp docs listed above
 
 ```
-# revaliases
-root:<VALUE_FROM_ROOT>:smtp.<YOUR_MAILBOX>
-nagios:<VALUE_FROM_ROOT>:smtp.<YOUR_MAILBOX>
-www-data:<VALUE_FROM_ROOT>:smtp.<YOUR_MAILBOX>
+# msmtp/msmtprc
+auth           on
+tls            on
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile        /var/log/msmtp.log
+aliases        /etc/aliases
+
+# Gmail
+account        gmail
+host           smtp.gmail.com
+port           587
+from           <your-email-address@gmail.com>
+user           <your-email-address@gmail.com>
+password       <your-password-or-eval-command-to-gpg-file>
+
+# Set a default account
+account default: gmail
+```
+
+*Note that Gmail has become very restrictive, the preparation and config must be done in Gmail's settings. If you can't get it to work, consider another SMTP service*.
+
+`msmtp/aliases` follows the format: `Unix-user: e-mail-address`.
+
+```
+# msmtp/aliases
+root:<YOUR_MAILBOX>
+default:<YOUR_MAILBOX>
 ```
 
 These files have to get mounted into the container. Add these flags to your `docker run`-command:
+
 ```
--v $(pwd)/revaliases:/etc/ssmtp/revaliases:ro
--v $(pwd)/ssmtp.conf:/etc/ssmtp/ssmtp.conf:ro
+-v $(pwd)/msmtp/aliases:/etc/msmtp/aliases:ro
+-v $(pwd)/msmtp/msmtprc:/etc/msmtp/msmtprc:ro
 ```
 
-If you want to change the display-name of sender-address, you have to define the variable `ICINGA2_USER_FULLNAME`.
+If you are using the `docker-compose` file, uncomment the settings for these files under the icinga2 node.
 
-If this does not work, please ask your provider for the correct mail-settings or consider the [ssmtp.conf(5)-manpage](https://manpages.debian.org/stretch/ssmtp/ssmtp.conf.5.en.html) or Section ["Reverse Aliases" on ssmtp(8)](https://manpages.debian.org/stretch/ssmtp/ssmtp.8.en.html#REVERSE_ALIASES).
-Also you can debug your config, by executing inside your container `ssmtp -v $address` and pressing 2x Enter.
-It will send an e-Mail to `$address` and give verbose log and all error-messages.
 
 ## SSL Support
 

--- a/content/etc/supervisor/conf.d/director.conf
+++ b/content/etc/supervisor/conf.d/director.conf
@@ -1,0 +1,9 @@
+[program:director]
+command=/opt/supervisor/director_supervisor
+autorestart=true
+startretries=3
+# redirect output to stdout/stderr and do not use a regular logfile
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/content/opt/supervisor/director_supervisor
+++ b/content/opt/supervisor/director_supervisor
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+/usr/bin/icingacli director daemon run &
+
+# Allow any signal which would kill a process to stop server
+trap "pkill --f icinga::director" HUP INT QUIT ABRT ALRM TERM TSTP
+
+while pgrep -u root -f director > /dev/null; do sleep 5; done

--- a/content/opt/supervisor/icinga2_supervisor
+++ b/content/opt/supervisor/icinga2_supervisor
@@ -9,6 +9,10 @@ if [ ! -e '/var/run/icinga2' ]; then
   chmod 2710 /var/run/icinga2/cmd
   chown nagios:nagios /var/run/icinga2
   chmod 0755 /var/run/icinga2
+  ln -fs /usr/local/share/icingaweb2/modules/ipl /etc/icingaweb2/enabledModules/
+  ln -fs /usr/local/share/icingaweb2/modules/incubator /etc/icingaweb2/enabledModules/
+  ln -fs /usr/local/share/icingaweb2/modules/reactbundle /etc/icingaweb2/enabledModules/
+  ln -fs /usr/bin/msmtp /usr/sbin/sendmail
 fi
 
 service icinga2 foreground &

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 version: '2'
 services:
   icinga2:
-    image: jordan/icinga2
+    #image: jordan/icinga2
+    build:
+      context: ./
+      dockerfile: Dockerfile
     restart: on-failure:5
     # Set your hostname to the FQDN under which your
     # sattelites will reach this container
@@ -34,13 +37,15 @@ services:
       - ./data/icinga/log/icingaweb2:/var/log/icingaweb2
       - ./data/icinga/log/mysql:/var/log/mysql
       - ./data/icinga/spool:/var/spool/icinga2
-      # If you want to enable outbound e-mail, create the files
-      #  - ./ssmtp/ssmtp.conf
-      #  - ./ssmtp/revaliases
-      #  and configure to your corresponding mail setup.
+      # Sending e-mail
       #  See: https://github.com/jjethwa/icinga2#sending-notification-mails
-      #- ./ssmtp/revaliases:/etc/ssmtp/revaliases:ro
-      #- ./ssmtp/ssmtp.conf:/etc/ssmtp/ssmtp.conf:ro
+      #  If you want to enable outbound e-mail, edit the file mstmp/msmtprc
+      #  and configure to your corresponding mail setup. The default is a
+      #  Gmail example but msmtp can be used for any MTA configuration.
+      #  Change the aliases in msmtp/aliases to your recipients.
+      #  Then uncomment the rows below
+      # - ./msmtp/msmtprc:/etc/msmtprc:ro
+      # - ./msmtp/aliases:/etc/aliases:ro
     ports:
       - "80:80"
       - "443:443"

--- a/msmtp/aliases
+++ b/msmtp/aliases
@@ -1,0 +1,2 @@
+root:<YOUR_MAILBOX>
+default:<YOUR_MAILBOX>

--- a/msmtp/msmtprc
+++ b/msmtp/msmtprc
@@ -1,0 +1,19 @@
+# Set default values for all following accounts.
+defaults
+
+auth           on
+tls            on
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile        /var/log/msmtp.log
+aliases        /etc/aliases
+
+# Gmail
+account        gmail
+host           smtp.gmail.com
+port           587
+from           <your-email-address@gmail.com>
+user           <your-email-address@gmail.com>
+password       <your-password-or-eval-command-to-gpg-file>
+
+# Set a default account
+account default: gmail


### PR DESCRIPTION
- Upgraded the Docker image to Debian Buster
- Newer version of Icinga2 is modularized and all default modules for Director are added
- Director is now running as its own daemon, controlled by Supervisor
- The `ssmtp` mail package is replaced with `msmtp`, default files added
- README updated with msmtp config howto

Please note that `docker-compose.yml` is using the local build instead of a released image.