### PR TITLE
README typo 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ You have to edit the file `msmtp/msmtprc` for general configuration and `msmtp/a
 
 ```
 # msmtp/msmtprc
+defaults
 auth           on
 tls            on
 tls_trust_file /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
README typo causing the #200 issue. The config documentation for `msmstp` was missing the default header causing msmtp to not find the default settings. 