### PR TITLE
Fix #164 (mysql initialization error)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - ./data/graphite/log/graphite:/var/log/graphite
       - ./data/graphite/log/carbon:/var/log/carbon
   mysql:
-    image: mariadb:10.1
+    image: mariadb
     env_file:
       - secrets_sql.env
     volumes:


### PR DESCRIPTION
You should not use static image versions in docker-compose files. A fixed version is good to go as long as there is a known incompatibility or known incompatible change planned in the future of the image. Otherwise, future versions are important always bug and security fixes.

My optional suggestion is to change `mysql.volumes` section to use **named volume** instead of directory for mysql data.

```yaml
version: "2"
volumes:
  mysql_data:
services:
  mysql:
    volumes:
      mysql_data:/var/lib/mysql
```

This is a more convenient way since volumes are not ephemeral in this case, but will not depend on directory of git clone (remains read-only in the best scenario)