### PR TITLE
Add missing logrotate package to images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libdigest-hmac-perl \
     libnet-snmp-perl \
     locales \
+    logrotate \
     lsb-release \
     bsd-mailx \
     mariadb-client \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -38,6 +38,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libdigest-hmac-perl \
     libnet-snmp-perl \
     locales \
+    logrotate \
     lsb-release \
     bsd-mailx \
     mariadb-client \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -39,6 +39,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     libdigest-hmac-perl \
     libnet-snmp-perl \
     locales \
+    logrotate \
     lsb-release \
     bsd-mailx \
     mariadb-client \


### PR DESCRIPTION
As detailed in https://github.com/jjethwa/icinga2/issues/193#issuecomment-783248626,
this package was missing, which meant the log rotation configs provided
by Icinga2 were never executed and the icinga logs grew forever.

Logrotate automatically configures its own cron when installed, so no
action is needed other than installing it.