### PR TITLE
add permission fix if using x509 check, because nagios user need to b…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ RUN true \
     && mkdir -p /etc/icinga2 \
     && usermod -aG icingaweb2 www-data \
     && usermod -aG nagios www-data \
+    && usermod -aG icingaweb2 nagios \
     && mkdir -p /var/log/icinga2 \
     && chmod 755 /var/log/icinga2 \
     && chown nagios:adm /var/log/icinga2 \

--- a/README.md
+++ b/README.md
@@ -262,3 +262,4 @@ All these folders are configured and able to get mounted as volume. The bottom o
 | /var/log/supervisor | rw | logfolder for supervisord (not neccessary) |
 | /var/spool/icinga2 | rw | spool-folder for icinga2 (not neccessary) |
 | /var/cache/icinga2 | rw | cache-folder for icinga2 (not neccessary) |
+| /etc/cron.d/icinga | rw | file for cron-daemon (not neccessary if not using x509) |


### PR DESCRIPTION
add permission fix if using x509 check, because nagios user need to be access into icingaweb2 for configuration reading part.

"icinga ERROR: Cannot read enabled modules. Config directory "/etc/icingaweb2" is not readable"

add message into readme how to mount cron file