### PR TITLE
Bullseye version upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for icinga2 with icingaweb2
 # https://github.com/jjethwa/icinga2
 
-FROM debian:buster
+FROM debian:bullseye
 
 ENV APACHE2_HTTP=REDIRECT \
     ICINGA2_FEATURE_GRAPHITE=false \
@@ -46,6 +46,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     php-gmp \
     procps \
     pwgen \
+    python \
     snmp \
     msmtp \
     sudo \
@@ -80,44 +81,44 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 ARG GITREF_MODGRAPHITE=master
 ARG GITREF_MODAWS=master
-ARG GITREF_REACTBUNDLE=v0.7.0
-ARG GITREF_INCUBATOR=v0.5.0
-ARG GITREF_IPL=v0.3.0
+ARG GITREF_REACTBUNDLE=v0.9.0
+ARG GITREF_INCUBATOR=v0.16.0
+ARG GITREF_IPL=v0.5.0
 
 RUN mkdir -p /usr/local/share/icingaweb2/modules/ \
     # Icinga Director
     && mkdir -p /usr/local/share/icingaweb2/modules/director/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/v1.8.1.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/v1.9.1.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/director --exclude=.gitignore -f - \
     # Icingaweb2 Graphite
     && mkdir -p /usr/local/share/icingaweb2/modules/graphite \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-graphite/archive/v1.1.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-graphite/archive/v1.2.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/graphite -f - \
     # Icingaweb2 AWS
     && mkdir -p /usr/local/share/icingaweb2/modules/aws \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-aws/archive/v1.0.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-aws/archive/v1.1.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/aws -f - \
-    && wget -q --no-cookies "https://github.com/aws/aws-sdk-php/releases/download/2.8.30/aws.zip" \
+    && wget -q --no-cookies "https://github.com/aws/aws-sdk-php/releases/download/3.222.8/aws.zip" \
     && unzip -d /usr/local/share/icingaweb2/modules/aws/library/vendor/aws aws.zip \
     && rm aws.zip \
     # Module Reactbundle
     && mkdir -p /usr/local/share/icingaweb2/modules/reactbundle/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-reactbundle/archive/v0.7.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-reactbundle/archive/v0.9.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/reactbundle -f - \
     # Module Incubator
     && mkdir -p /usr/local/share/icingaweb2/modules/incubator/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-incubator/archive/v0.6.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-incubator/archive/v0.16.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/incubator -f - \
     # Module Ipl
     && mkdir -p /usr/local/share/icingaweb2/modules/ipl/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-ipl/archive/v0.3.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-ipl/archive/v0.5.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/ipl -f - \
     # Module x509
     && mkdir -p /usr/local/share/icingaweb2/modules/x509/ \
-    && wget -q --no-cookies "https://github.com/Icinga/icingaweb2-module-x509/archive/v1.0.0.zip" \
-    && unzip -d /usr/local/share/icingaweb2/modules/x509 v1.0.0.zip \
-    && mv /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.0.0/* /usr/local/share/icingaweb2/modules/x509/ \
-    && rm -rf /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.0.0/ \
+    && wget -q --no-cookies "https://github.com/Icinga/icingaweb2-module-x509/archive/v1.1.2.zip" \
+    && unzip -d /usr/local/share/icingaweb2/modules/x509 v1.1.2.zip \
+    && mv /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.1.2/* /usr/local/share/icingaweb2/modules/x509/ \
+    && rm -rf /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.1.2/ \
     && true
 
 ADD content/ /

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,5 +1,5 @@
 # Dockerfile for icinga2 with icingaweb2
-FROM debian:buster AS qemu_arm32
+FROM debian:bullseye AS qemu_arm32
 
 #QEMU Download
 ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v4.0.0%2Bdev.2%2Bjenkins-balena-qemu-21/qemu-4.0.0.dev.2.jenkins-balena-qemu-21-arm.tar.gz
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && curl -k -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
 
-FROM arm32v7/debian:buster
+FROM arm32v7/debian:bullseye
 # Add QEMU
 COPY --from=qemu_arm32 qemu-arm-static /usr/bin
 
@@ -54,6 +54,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     php-gmp \
     procps \
     pwgen \
+    python \
     snmp \
     msmtp \
     sudo \
@@ -88,44 +89,44 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 ARG GITREF_MODGRAPHITE=master
 ARG GITREF_MODAWS=master
-ARG GITREF_REACTBUNDLE=v0.7.0
-ARG GITREF_INCUBATOR=v0.5.0
-ARG GITREF_IPL=v0.3.0
+ARG GITREF_REACTBUNDLE=v0.9.0
+ARG GITREF_INCUBATOR=v0.16.0
+ARG GITREF_IPL=v0.5.0
 
 RUN mkdir -p /usr/local/share/icingaweb2/modules/ \
     # Icinga Director
     && mkdir -p /usr/local/share/icingaweb2/modules/director/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/v1.8.1.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/v1.9.1.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/director --exclude=.gitignore -f - \
     # Icingaweb2 Graphite
     && mkdir -p /usr/local/share/icingaweb2/modules/graphite \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-graphite/archive/v1.1.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-graphite/archive/v1.2.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/graphite -f - \
     # Icingaweb2 AWS
     && mkdir -p /usr/local/share/icingaweb2/modules/aws \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-aws/archive/v1.0.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-aws/archive/v1.1.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/aws -f - \
-    && wget -q --no-cookies "https://github.com/aws/aws-sdk-php/releases/download/2.8.30/aws.zip" \
+    && wget -q --no-cookies "https://github.com/aws/aws-sdk-php/releases/download/3.222.8/aws.zip" \
     && unzip -d /usr/local/share/icingaweb2/modules/aws/library/vendor/aws aws.zip \
     && rm aws.zip \
     # Module Reactbundle
     && mkdir -p /usr/local/share/icingaweb2/modules/reactbundle/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-reactbundle/archive/v0.7.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-reactbundle/archive/v0.9.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/reactbundle -f - \
     # Module Incubator
     && mkdir -p /usr/local/share/icingaweb2/modules/incubator/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-incubator/archive/v0.6.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-incubator/archive/v0.16.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/incubator -f - \
     # Module Ipl
     && mkdir -p /usr/local/share/icingaweb2/modules/ipl/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-ipl/archive/v0.3.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-ipl/archive/v0.5.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/ipl -f - \
     # Module x509
     && mkdir -p /usr/local/share/icingaweb2/modules/x509/ \
-    && wget -q --no-cookies "https://github.com/Icinga/icingaweb2-module-x509/archive/v1.0.0.zip" \
-    && unzip -d /usr/local/share/icingaweb2/modules/x509 v1.0.0.zip \
-    && mv /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.0.0/* /usr/local/share/icingaweb2/modules/x509/ \
-    && rm -rf /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.0.0/ \
+    && wget -q --no-cookies "https://github.com/Icinga/icingaweb2-module-x509/archive/v1.1.2.zip" \
+    && unzip -d /usr/local/share/icingaweb2/modules/x509 v1.1.2.zip \
+    && mv /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.1.2/* /usr/local/share/icingaweb2/modules/x509/ \
+    && rm -rf /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.1.2/ \
     && true
 
 ADD content/ /

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,5 +1,5 @@
 # Dockerfile for icinga2 with icingaweb2
-FROM debian:buster AS qemu_arm64
+FROM debian:bullseye AS qemu_arm64
 
 #QEMU Download
 ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v4.0.0%2Bdev.2%2Bjenkins-balena-qemu-21/qemu-4.0.0.dev.2.jenkins-balena-qemu-21-aarch64.tar.gz
@@ -8,7 +8,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && curl -k -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
 
-FROM arm64v8/debian:buster
+FROM arm64v8/debian:bullseye
 # Add QEMU
 COPY --from=qemu_arm64 qemu-aarch64-static /usr/bin
 
@@ -55,6 +55,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     php-gmp \
     procps \
     pwgen \
+    python \
     snmp \
     msmtp \
     sudo \
@@ -89,44 +90,44 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 ARG GITREF_MODGRAPHITE=master
 ARG GITREF_MODAWS=master
-ARG GITREF_REACTBUNDLE=v0.7.0
-ARG GITREF_INCUBATOR=v0.5.0
-ARG GITREF_IPL=v0.3.0
+ARG GITREF_REACTBUNDLE=v0.9.0
+ARG GITREF_INCUBATOR=v0.16.0
+ARG GITREF_IPL=v0.5.0
 
 RUN mkdir -p /usr/local/share/icingaweb2/modules/ \
     # Icinga Director
     && mkdir -p /usr/local/share/icingaweb2/modules/director/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/v1.8.1.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-director/archive/v1.9.1.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/director --exclude=.gitignore -f - \
     # Icingaweb2 Graphite
     && mkdir -p /usr/local/share/icingaweb2/modules/graphite \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-graphite/archive/v1.1.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-graphite/archive/v1.2.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/graphite -f - \
     # Icingaweb2 AWS
     && mkdir -p /usr/local/share/icingaweb2/modules/aws \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-aws/archive/v1.0.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-aws/archive/v1.1.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/aws -f - \
-    && wget -q --no-cookies "https://github.com/aws/aws-sdk-php/releases/download/2.8.30/aws.zip" \
+    && wget -q --no-cookies "https://github.com/aws/aws-sdk-php/releases/download/3.222.8/aws.zip" \
     && unzip -d /usr/local/share/icingaweb2/modules/aws/library/vendor/aws aws.zip \
     && rm aws.zip \
     # Module Reactbundle
     && mkdir -p /usr/local/share/icingaweb2/modules/reactbundle/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-reactbundle/archive/v0.7.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-reactbundle/archive/v0.9.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/reactbundle -f - \
     # Module Incubator
     && mkdir -p /usr/local/share/icingaweb2/modules/incubator/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-incubator/archive/v0.6.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-incubator/archive/v0.16.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/incubator -f - \
     # Module Ipl
     && mkdir -p /usr/local/share/icingaweb2/modules/ipl/ \
-    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-ipl/archive/v0.3.0.tar.gz" \
+    && wget -q --no-cookies -O - "https://github.com/Icinga/icingaweb2-module-ipl/archive/v0.5.0.tar.gz" \
     | tar xz --strip-components=1 --directory=/usr/local/share/icingaweb2/modules/ipl -f - \
     # Module x509
     && mkdir -p /usr/local/share/icingaweb2/modules/x509/ \
-    && wget -q --no-cookies "https://github.com/Icinga/icingaweb2-module-x509/archive/v1.0.0.zip" \
-    && unzip -d /usr/local/share/icingaweb2/modules/x509 v1.0.0.zip \
-    && mv /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.0.0/* /usr/local/share/icingaweb2/modules/x509/ \
-    && rm -rf /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.0.0/ \
+    && wget -q --no-cookies "https://github.com/Icinga/icingaweb2-module-x509/archive/v1.1.2.zip" \
+    && unzip -d /usr/local/share/icingaweb2/modules/x509 v1.1.2.zip \
+    && mv /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.1.2/* /usr/local/share/icingaweb2/modules/x509/ \
+    && rm -rf /usr/local/share/icingaweb2/modules/x509/icingaweb2-module-x509-1.1.2/ \
     && true
 
 ADD content/ /


### PR DESCRIPTION
* Updated to a new baseimage debian bullseye from debian buster.
* Installing python2 (Because bullseye uses python3 by default. But Icingaweb2 needs python2)
* Updated the following version of the following icingaweb2 modules:
   * icingaweb2-module-director: v1.8.1 -> v1.9.1
   * icingaweb2-module-graphite: v1.1.0 -> v1.2.0
   * icingaweb2-module-aws: v1.0.0 -> v1.1.0
   * aws-sdk-php: 2.8.30 -> 3.222.8
   * icingaweb2-module-reactbundle: v0.7.0 -> v0.9.0
   * icingaweb2-module-incubator: v0.6.0 -> v0.16.0
   * icingaweb2-module-ipl: v0.3.0 -> v0.5.0
   * icingaweb2-module-x509: v1.0.0 -> v1.1.2
   
   **Remark:** The docker image created by Dockerfile is tested in my environment and working fine. But I have no ability to test the ARM docker images (Dockerfile.arm32v7 + Dockerfile.arm64v8) so these are currently untested.