### PR TITLE
Add jq and telnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     dnsutils \
     file \
     gnupg \
+    jq \
     libdbd-mysql-perl \
     libdigest-hmac-perl \
     libnet-snmp-perl \
@@ -51,6 +52,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     msmtp \
     sudo \
     supervisor \
+    telnet \
     unzip \
     wget \
     cron \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -35,6 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     dnsutils \
     file \
     gnupg \
+    jq \
     libdbd-mysql-perl \
     libdigest-hmac-perl \
     libnet-snmp-perl \
@@ -59,6 +60,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     msmtp \
     sudo \
     supervisor \
+    telnet \
     unzip \
     wget \
     cron \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     dnsutils \
     file \
     gnupg \
+    jq \
     libdbd-mysql-perl \
     libdigest-hmac-perl \
     libnet-snmp-perl \
@@ -60,6 +61,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     msmtp \
     sudo \
     supervisor \
+    telnet \
     unzip \
     wget \
     cron \


### PR DESCRIPTION
Hi @jjethwa it would be great if you could integrate jq and telnet into your image.

I have made the following changes in this pull request:
* add jq
* add telnet

These changes work fine for me in the x86_64 environment. ARM environment was not tested.

---
**Justification**

* jq is needed to run the plugin `check_prometheus_metric.sh`. (if you use prometheus) 
* telnet is needed to test if ports are reachable. This makes testing much easier.
